### PR TITLE
use postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@
 ## Get started
 
 ```bash
-$ nvm install iojs
 $ npm install
-$ npm run rebuild-leveldb
 $ npm start
 ```
 
-  Then check `window.db` for your ready to use leveldb.
+  Then check `window.db` and you're ready to use leveldb.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "levelup": "^1.2.1"
   },
   "scripts": {
-    "rebuild-leveldb": "cd node_modules/leveldown && HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell",
+    "postinstall": "cd node_modules/leveldown && HOME=~/.electron-gyp node-gyp rebuild --target=0.29.1 --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "electron ."
   },
   "devDependencies": {


### PR DESCRIPTION
Use `npm postinstall` since it's one less step. Also remove the
`nvm install iojs` line because Node is at 4.0.0 now. Hopefully
they should be running the latest Node.

Also fixes a spelling error in the README.