### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "levelup": "^1.2.1"
   },
   "scripts": {
-    "postinstall": "cd node_modules/leveldown && HOME=~/.electron-gyp node-gyp rebuild --target=0.36.2 --arch=x64 --dist-url=https://atom.io/download/atom-shell",
+    "postinstall": "cd node_modules/leveldown && HOME=~/.electron-gyp node-gyp rebuild --target=0.36.8 --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "electron ."
   },
   "devDependencies": {
-    "electron-prebuilt": "0.36.2"
+    "electron-prebuilt": "0.36.10"
   }
 }


### PR DESCRIPTION
greenkeeper is only updating the npm dep, but the post install step should target the latest release as well. Should close #21.